### PR TITLE
Ignore user .DS_Stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store 
 
 # Xcode
 #
@@ -17,3 +18,5 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+
+


### PR DESCRIPTION
First removed .DS_Store from Git tracking. Then added .DS_Store to .gitignore.

The file has nothing to do with the code that is being tracked in git. It contains custom attributes set on the containing folder in the Finder. Unless those custom attributes are relevant to the code, that file is just noise. Additionally, if the file is not ignored and gets checked in unintentionally and later two devs each decide to put say, pretty custom icons on the folder (for whatever reason), then you could end up with a merge conflict on a binary file.